### PR TITLE
Add doas and root user support

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,10 +2,24 @@
 
 # run script for linux remote desktop bootstrap
 
+# sudo wrapper
+SUDO=$(command -v sudo)
+if [ -z "$SUDO" ]; then
+      echo "sudo is not present, attempting to use doas..."
+      SUDO=$(command -v doas)
+      if [ -z "$SUDO" ]; then
+            echo "doas is also not present, checking if running as root..."
+            if [[ $(id -u) -ne 0 ]]; then
+                echo "Running as regular user! Subsequent steps will fail, aborting..."
+                exit 4;
+            fi
+      fi
+fi
+
 #check if docker exists
 if [ -x "$(command -v docker)" ]; then
     # pull latest linux-remote-desktop image
-    sudo docker pull nubosoftware/linux-remote-desktop:latest
+    $SUDO docker pull nubosoftware/linux-remote-desktop:latest
 else
     echo "Docker not found. Please install Docker engine"
     exit 1;
@@ -14,7 +28,7 @@ fi
 if [ ! -d "/etc/docker" ] 
 then   
     echo "Directory /etc/docker does not exists. Creating it.."
-    sudo mkdir -p /etc/docker
+    $SUDO mkdir -p /etc/docker
 fi
 
 if [ ! -f /etc/docker/daemon.json ]; then
@@ -26,14 +40,14 @@ fi
 if [ ! -d "/opt/nubo" ] 
 then   
     echo "Directory /opt/nubo does not exists. Creating it.."
-    sudo mkdir -p /opt/nubo
+    $SUDO mkdir -p /opt/nubo
 fi
 
 # run the bootstrap image in loop until we get exit code that is 0 or 1
 i="100"
 while [ $i -gt 1 ]
 do
-    sudo docker run \
+    $SUDO docker run \
         -e DEF_HOSTNAME="$HOSTNAME" \
         -e DOCKER_ENV='YES' \
         -v /etc/docker:/etc/docker \
@@ -44,6 +58,6 @@ do
     if [ $i -eq 2 ] 
     then 
         echo "Reload docker"
-        sudo systemctl reload docker
+        $SUDO systemctl reload docker
     fi
 done


### PR DESCRIPTION
Some systems might contain doas instead of sudo, e.g. Alpine or Gentoo. Or they can contain only root user, since the environment is either isolated or secured otherwise. This commit adds preflight checks and generalizes further steps. TODO: distro parsing, init-system detection, check if user is present in docker group, refactor excessive IF usage.